### PR TITLE
Rename 'Wraper' import to 'Wrapper'

### DIFF
--- a/src/preact/index.js
+++ b/src/preact/index.js
@@ -1,9 +1,9 @@
-import Wraper from '../index';
+import Wrapper from '../index';
 
 let { 
 	Form, 
 	connectForm, 
-} = Wraper(require('preact'));
+} = Wrapper(require('preact'));
 
 export {
 	Form,

--- a/src/react/index.js
+++ b/src/react/index.js
@@ -1,9 +1,9 @@
-import Wraper from '../index';
+import Wrapper from '../index';
 
 let { 
 	Form, 
 	connectForm, 
-} = Wraper(require('react'));
+} = Wrapper(require('react'));
 
 export {
 	Form,


### PR DESCRIPTION
## Description

This PR:
* Fixes a typo, `Wrapper` was misspelled as `Wraper`

:tada: 